### PR TITLE
Rename project from Dyad.sh to Codex across all configuration files

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -74,9 +74,9 @@ The application follows Angular's component-based architecture:
 - Use trackBy functions in @for loops
 - Optimize bundle size with tree shaking
 
-## Dyad.sh Compatibility
+## Codex Compatibility
 
-This template is optimized for Dyad.sh environment:
+This template is optimized for Codex environment:
 - Minimal dependencies
 - Fast development server startup
 - Efficient production builds

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Dyad Angular Template
+# Codex Angular Template
 
-A minimal Angular template for Dyad.sh - a clean starting point for building Angular applications.
+A minimal Angular template for Codex - a clean starting point for building Angular applications.
 
 ## Overview
 
-This template provides a minimal, unopinionated Angular application setup that's fully compatible with Dyad.sh's JavaScript-based environment. It includes:
+This template provides a minimal, unopinionated Angular application setup that's fully compatible with Codex's JavaScript-based environment. It includes:
 
 - Latest stable Angular (v17)
 - TypeScript support
@@ -62,4 +62,4 @@ src/
 
 ## License
 
-This template is open source and available for use in your Dyad.sh projects.
+This template is open source and available for use in your Codex projects.

--- a/angular-webpack-component-tagger.js
+++ b/angular-webpack-component-tagger.js
@@ -1,6 +1,6 @@
 /**
- * Angular Webpack Component Tagger for Dyad.sh
- * Adds data-dyad-id and data-dyad-name attributes to Angular components
+ * Angular Webpack Component Tagger for Codex
+ * Adds data-codex-id and data-codex-name attributes to Angular components
  * Compatible with Angular's AOT compilation and Ivy renderer
  */
 
@@ -59,8 +59,8 @@ class AngularComponentTagger {
                   
                   // Insert data attributes after the element start
                   const dataAttributes = `
-                    ɵɵattribute("data-dyad-id", "${filePath}:0:0");
-                    ɵɵattribute("data-dyad-name", "${componentName}");
+                      ɵɵattribute("data-codex-id", "${filePath}:0:0");
+  ɵɵattribute("data-codex-name", "${componentName}");
                   `;
                   
                   return elementStart + ';' + dataAttributes;
@@ -76,8 +76,8 @@ class AngularComponentTagger {
                   const filePath = filePathMatch ? filePathMatch[1].replace(/\\/g, '/') + '.ts' : pathname;
                   
                   // Add data attributes if not already present
-                  if (!attributes.includes('data-dyad-id')) {
-                    return `<${tagName} data-dyad-id="${filePath}:0:0" data-dyad-name="${componentName}"${attributes}>`;
+                      if (!attributes.includes('data-codex-id')) {
+      return `<${tagName} data-codex-id="${filePath}:0:0" data-codex-name="${componentName}"${attributes}>`;
                   }
                 }
                 return match;

--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "dyad-angular-template": {
+    "codex-angular-template": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:class": {
@@ -41,7 +41,7 @@
             "customWebpackConfig": {
               "path": "./webpack.config.js"
             },
-            "outputPath": "dist/dyad-angular-template",
+            "outputPath": "dist/codex-angular-template",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": [
@@ -85,10 +85,10 @@
           "builder": "@angular-builders/custom-webpack:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "dyad-angular-template:build:production"
+              "buildTarget": "codex-angular-template:build:production"
             },
             "development": {
-              "buildTarget": "dyad-angular-template:build:development"
+              "buildTarget": "codex-angular-template:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -96,7 +96,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "buildTarget": "dyad-angular-template:build"
+            "buildTarget": "codex-angular-template:build"
           }
         },
         "test": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dyad-angular-template",
+  "name": "codex-angular-template",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dyad-angular-template",
+      "name": "codex-angular-template",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dyad-angular-template",
+  "name": "codex-angular-template",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,7 @@
 <div class="main">
   <img src="https://angular.io/assets/images/logos/angular/angular.svg" alt="Angular Logo" width="120">
   <h1>Welcome to your Angular App!</h1>
-  <p>This is a minimal template for Dyad.sh with Select UI to Edit support.</p>
+      <p>This is a minimal template for Codex with Select UI to Edit support.</p>
   <p>Edit <code>src/app/app.component.ts</code> to get started.</p>
   
   <app-hello></app-hello>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,5 +9,5 @@ import { HelloComponent } from './hello/hello.component';
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  title = 'dyad-angular-template';
+  title = 'codex-angular-template';
 }

--- a/src/app/hello/hello.component.ts
+++ b/src/app/hello/hello.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   template: `
     <div class="hello">
       <h2>Hello Component</h2>
-      <p>This is an example component to demonstrate Dyad.sh Select UI to Edit feature.</p>
+      <p>This is an example component to demonstrate Codex Select UI to Edit feature.</p>
     </div>
   `,
   styles: [`

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>DyadAngularTemplate</title>
+      <title>CodexAngularTemplate</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 /**
  * Webpack configuration for Angular Component Tagging
- * This enables Select UI to Edit feature in Dyad.sh
+ * This enables Select UI to Edit feature in Codex
  */
 
 const AngularComponentTagger = require('./angular-webpack-component-tagger');


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the project from Dyad.sh to Codex in all configuration files, code comments, and documentation to reflect the new branding. All references, data attributes, and project names now use "Codex" instead of "Dyad.sh".

<!-- End of auto-generated description by cubic. -->

